### PR TITLE
Fix unusual error caused by xpath interpreted as css

### DIFF
--- a/lib/premailer/adapter/nokogumbo.rb
+++ b/lib/premailer/adapter/nokogumbo.rb
@@ -40,7 +40,13 @@ class Premailer
               # than one element.  Added to work around dodgy generated code.
               selector.gsub!(/\A\#([\w_\-]+)\Z/, '*[@id=\1]')
 
-              doc.search(selector).each do |el|
+              search_results = doc.search(selector)
+              if search_results == true || search_results == false
+                $stderr.puts "CSS query returned boolean with selector: #{selector} - possibly due to xpath interpretation"
+                next
+              end
+
+              search_results.each do |el|
                 if el.elem? and (el.name != 'head' and el.parent.name != 'head')
                   # Add a style attribute or append to the existing one
                   block = "[SPEC=#{specificity}[#{declaration}]]"

--- a/test/test_premailer.rb
+++ b/test/test_premailer.rb
@@ -108,6 +108,13 @@ END_HTML
     end
   end
 
+  def test_boolean_xpath_as_css_for_nokogumbo
+    html = '<style>// .orange { color:red }</style><td style="background-color: #FFF;">hey</td>'
+    premailer = Premailer.new(html, {:with_html_string => true, :adapter => :nokogumbo, :css_to_attributes => true})
+    premailer.to_inline_css
+    assert_equal 'hey', premailer.processed_doc.text
+  end
+
   def test_avoid_changing_css_to_attributes
     [:nokogiri, :nokogiri_fast, :nokogumbo].each do |adapter|
       html = '<td style="background-color: #FFF;"></td>'


### PR DESCRIPTION
Given a fragment like this:

```html
<style>
// .orange { color: red }
</style>
<span class="orange">hey</span>
```

In this fragment the CSS selector is commented out: `// .orange`.

However this is also valid xpath, as documented [here](https://github.com/sparklemotion/nokogiri/issues/1414#issuecomment-175029484).

When passed to nokogiri search: `document.search("// .orange")`, it is interpreted as the xpath: `// . or ange`, which is a boolean query that always returns true:

> So the query ".orange" is being parsed and interpreted as ". or ange". In XPath, "." refers to the context node, which always exists, and so this is truthy. "ange" refers to a node named ange, which doesn't exist in this doc and is hence "falsey".

fixes https://app.bugsnag.com/consider/production-backend/errors/5cc0ad5bad6a9d0019f9c7d6?event_id=5cc0ad5b0038cb3757670000&i=sk&m=nw